### PR TITLE
Bug in ecan1_init

### DIFF
--- a/ecanFunctions.c
+++ b/ecanFunctions.c
@@ -40,7 +40,7 @@ void ecan1_init(const uint16_t *parameters)
     while (C1CTRL1bits.OPMODE != 4);
 
     // Initialize our circular buffers. If this fails, we crash and burn.
-    if (!CB_Init(&ecan1_tx_buffer, rx_data_array, ARRAYSIZE)) {
+    if (!CB_Init(&ecan1_tx_buffer, tx_data_array, ARRAYSIZE)) {
         while (1);
     }
     if (!CB_Init(&ecan1_rx_buffer, rx_data_array, ARRAYSIZE)) {


### PR DESCRIPTION
This commit fixes a bug where both circular buffers being initialized in `ecan1_init` point to the rx array instead of pointing to the rx and tx arrays
